### PR TITLE
Add CI/CD pipeline for GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,31 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# CI/CD with GitHub Actions
+
+This repository uses GitHub Actions to automate the CI/CD process. The workflow is configured to run on pushes to the `main` branch and deploys the project to GitHub Pages.
+
+## Triggering the CI/CD Pipeline
+
+To trigger the CI/CD pipeline, simply push your changes to the `main` branch. The GitHub Actions workflow will automatically start and handle the build and deployment process.
+
+## Deployment to GitHub Pages
+
+The project is deployed to GitHub Pages. After the CI/CD pipeline completes, the latest version of the project will be available on the GitHub Pages site for this repository.


### PR DESCRIPTION
Add CI/CD pipeline using GitHub Actions to deploy to GitHub Pages on commits to the main branch.

* **README.md**
  - Add a section to describe the CI/CD process using GitHub Actions.
  - Include instructions on how to trigger the CI/CD pipeline.
  - Mention the deployment to GitHub Pages.

* **.github/workflows/ci-cd.yml**
  - Create a GitHub Actions workflow file.
  - Configure the workflow to run on pushes to the `main` branch.
  - Add steps to build the project.
  - Add steps to deploy the project to GitHub Pages.

